### PR TITLE
Fixed BC between php-stdio-react 2.0 and tinker

### DIFF
--- a/src/Commands/Tinker.php
+++ b/src/Commands/Tinker.php
@@ -55,7 +55,7 @@ class Tinker extends Command
 
             $botman->setDriver(new ConsoleDriver($config, $stdio));
 
-            $stdio->on('line', function ($line) use ($botman) {
+            $stdio->on('data', function ($line) use ($botman) {
                 $botman->listen();
             });
 

--- a/src/Drivers/ConsoleDriver.php
+++ b/src/Drivers/ConsoleDriver.php
@@ -44,8 +44,8 @@ class ConsoleDriver implements DriverInterface
         $this->config = Collection::make($config);
         $this->client = $client;
 
-        $this->client->on('line', function ($line) {
-            $this->message = $line;
+        $this->client->on('data', function ($line) {
+            $this->message = rtrim($line, "\r\n");
         });
     }
 
@@ -114,7 +114,7 @@ class ConsoleDriver implements DriverInterface
      */
     public function types(IncomingMessage $matchingMessage)
     {
-        $this->client->writeln(self::BOT_NAME.': ...');
+        $this->client->write(self::BOT_NAME.': ...'.PHP_EOL);
     }
 
     /**
@@ -163,11 +163,11 @@ class ConsoleDriver implements DriverInterface
     public function sendPayload($payload)
     {
         $questionData = $payload['questionData'];
-        $this->client->writeln(self::BOT_NAME.': '.$payload['text']);
+        $this->client->write(self::BOT_NAME.': '.$payload['text'].PHP_EOL);
 
         if (! is_null($questionData)) {
             foreach ($questionData['actions'] as $key => $action) {
-                $this->client->writeln(($key + 1).') '.$action['text']);
+                $this->client->write(($key + 1).') '.$action['text'].PHP_EOL);
             }
             $this->hasQuestion = true;
             $this->lastQuestions = $questionData['actions'];


### PR DESCRIPTION
Corrected deprecated 'line' event and writeln method calls, since they changed event names from to 'data' and dropped the method writeln() in favor of using PHP_EOL.