### PR TITLE
Update supported Laravel verison

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "php": ">=5.6.0",
         "botman/botman": "~2.0",
         "clue/stdio-react": "~1.1.0 | ^2.0",
-        "illuminate/support": "~5.0"
+        "illuminate/support": "~5.8.0 | ^6.0",
+        "illuminate/console": "~5.8.0 | ^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,6 @@
         "clue/stdio-react": "~1.1.0 | ^2.0",
         "illuminate/support": "~5.0"
     },
-    "require-dev": {
-        "orchestra/testbench": "~3.0",
-        "phpunit/phpunit": "~5.0"
-    },
     "autoload": {
         "psr-4": {
             "BotMan\\Tinker\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,11 @@
         "php": ">=5.6.0",
         "botman/botman": "~2.0",
         "clue/stdio-react": "^2.0",
-        "illuminate/support": "~5.8.0 | ^6.0",
-        "illuminate/console": "~5.8.0 | ^6.0"
+        "illuminate/support": "~5.5.0 || ~5.6.0 || ~5.7.0 || ~5.8.0 || ^6.0",
+        "illuminate/console": "~5.5.0 || ~5.6.0 || ~5.7.0 || ~5.8.0 || ^6.0"
+    },
+    "require-dev": {
+        "orchestra/testbench": "^3.5 || ^3.6 || ^3.7 || ^3.8 || ^4.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.6.0",
         "botman/botman": "~2.0",
-        "clue/stdio-react": "~1.1.0 | ^2.0",
+        "clue/stdio-react": "^2.0",
         "illuminate/support": "~5.8.0 | ^6.0",
         "illuminate/console": "~5.8.0 | ^6.0"
     },

--- a/src/Commands/Tinker.php
+++ b/src/Commands/Tinker.php
@@ -26,16 +26,6 @@ class Tinker extends Command
     protected $description = 'Tinker around with BotMan.';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return mixed

--- a/src/Commands/Tinker.php
+++ b/src/Commands/Tinker.php
@@ -51,7 +51,7 @@ class Tinker extends Command
             $botman = BotManFactory::create($config, new ArrayCache());
 
             $stdio = new Stdio($loop);
-            $stdio->getReadline()->setPrompt('You: ');
+            $stdio->setPrompt('You: ');
 
             $botman->setDriver(new ConsoleDriver($config, $stdio));
 


### PR DESCRIPTION
Hi @mpociot

This PR closes #14 

- limit support: Laravel 5.5 up to 6.x.
- removed phpunit since there are no tests
- removed getReadline() since its deprecated - clue/reactphp-stdio#84

cheers